### PR TITLE
Fix Test: replace all base/head placeholder in pull request description

### DIFF
--- a/src/pullRequestDescription.md
+++ b/src/pullRequestDescription.md
@@ -18,11 +18,11 @@ Merge `{{head}}` into `{{base}}`.
 # Manual Merge Guidance
 
 ```shell
-git checkout {{head}}
-git pull origin {{head}}
-git checkout {{base}}
-git pull origin {{base}}
-git merge {{head}}
+git checkout `{{head}}`
+git pull origin `{{head}}`
+git checkout `{{base}}`
+git pull origin `{{base}}`
+git merge `{{head}}`
 ```
 
 # Note

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -77,11 +77,13 @@ function getPullRequestPayload (base, head) {
   result.body = description
   let bodyHead = '`' + head + '`'
   let bodyBase = '`' + base + '`'
-  result.body = result.body.replace('`{{head}}`', bodyHead)
-  result.body = result.body.replace('`{{head}}`', bodyHead)
-  result.body = result.body.replace('`{{base}}`', bodyBase)
-  result.body = result.body.replace('`{{base}}`', bodyBase)
+  result.body = replaceAll(result.body, '`{{head}}`', bodyHead)
+  result.body = replaceAll(result.body, '`{{base}}`', bodyBase)
   return result
+}
+
+function replaceAll (str, from, to) {
+  return str.replace(new RegExp(from, 'g'), to)
 }
 
 function getPushPayload (branchName) {


### PR DESCRIPTION
Tests are currently not working due to the fact that the test did not replace all {{head}} and {{base}} placeholders in the pull request description template. 

This PR introduces a replaceAll method that conveniently takes care of above mentioned issue.