### PR TITLE
Manually resolved conflicts need to actually land in base branch

### DIFF
--- a/src/pullRequestDescription.md
+++ b/src/pullRequestDescription.md
@@ -13,7 +13,7 @@ Merge `{{head}}` into `{{base}}`.
 
 # Who
 
-👋 This is a message from your helpful GitHub App [branch-updater](https://github.com/instana/branch-updater).*
+*👋 This is a message from your helpful GitHub App [branch-updater](https://github.com/instana/branch-updater).*
 
 # Manual Merge Guidance
 
@@ -24,6 +24,35 @@ git checkout {{base}}
 git pull origin {{base}}
 git merge {{head}}
 ```
+
+Now resolve the conflicts locally.
+
+```
+# Edit files to resolve all conflicts:
+git add .
+git commit
+```
+
+*Please take care that these changes actually land in `{{base}}` as quickly as possible, so the next person
+that needs to merge changes from `{{head}}` to `{{base}}` does not encounter the same conflicts that you just resolved.*
+
+In case you can push to `{{base}}` directly:
+
+```
+git push
+```
+
+Depending on the repository and target branch, direct pushes to `{{base}}` might be forbidden. In that case, you need to
+create another branch (based on `{{base}}`) and a corresponding PR:
+
+```
+git checkout -b resolve-conflicts-{{head}}-{{base}}
+git push -u origin resolve-conflicts-{{head}}-{{base}}
+# The command line output of the git push command will provide a URL to conveniently create the PR.
+```
+
+Take care that this PR is merged into `{{base}}` as
+soon as possible (you might be able to merge it yourself once the required checks have completed).
 
 # Note
 


### PR DESCRIPTION
Just had the situation:

* somebody had already prepared a branch and a PR where a certain conflict had been resolved, but it hadn't been merged yet. I was unaware that this work had already happened.
* I wanted to merge the PR automatically created by branch-updater and encountered the same conflict that the other person had already solved and pinged them about it. Since the other person was not available, I then resolved it myself after a while checking which update had occurred in which branch in which order.

The underlying reason is that the current instructions stop too early IMO: They do not explain spell out explicitly how to land the changes in the base branch.

In particular, in repositories where direct pushes to the base branch are not allowed, this is not totally obvious.

This PR aims at expanding the instructions to make that less likely to happen.