### PR TITLE
Prevent cross-comparison between branch types and version formats

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const { ProbotOctokit } = require('probot')
 const path = require('path')
 const fs = require('fs')
-const { changeSourceRegEx, compareBranches } = require('./version-utils')
+const { changeSourceRegEx, compareBranches, extractVersion } = require('./version-utils')
 
 const description = fs.readFileSync(path.join(__dirname, 'pullRequestDescription.md'), { encoding: 'utf8' })
 const branchReferencePrefix = 'refs/heads/'
@@ -93,8 +93,30 @@ async function onPush (context, prApprovalOctokit) {
     res => res.data.map(branch => branch.name)
   )
 
+  // Determine the branch type (patch or release) and version type (integer or semver) of the current branch
+  const branchType = branch.toLowerCase().startsWith('patch-') ? 'patch' : 'release'
+  const currentVersion = extractVersion(branch)
+  const versionType = currentVersion ? currentVersion.versionType : null
+
+  // Filter branches to only include the same type and version format as the current branch
+  // This ensures we never compare:
+  // - patch branches with release branches
+  // - integer versions with semver versions
   const releaseBranches = allBranches
     .filter(isReleaseBranch)
+    .filter(b => {
+      const bType = b.toLowerCase().startsWith('patch-') ? 'patch' : 'release'
+      if (bType !== branchType) {
+        return false
+      }
+
+      const bVersion = extractVersion(b)
+      if (!bVersion || !versionType) {
+        return false
+      }
+
+      return bVersion.versionType === versionType
+    })
     .sort(compareBranches)
 
   let base = null

--- a/src/version-utils.js
+++ b/src/version-utils.js
@@ -2,23 +2,25 @@
 const changeSourceRegEx = /^(?:patch|release)-(?:\d+|v?\d+\.\d+\.x)$/i
 
 /**
- * Extract version from branch name
+ * Extract version and branch type from branch name
  * @param {string} branch - Branch name like 'release-147' or 'patch-v1.2.x'
- * @returns {object} - { type: 'integer'|'semver', value: number|{major, minor} }
+ * @returns {object} - { branchType: 'patch'|'release', versionType: 'integer'|'semver', value: number|{major, minor} }
  */
 function extractVersion (branch) {
-  const match = branch.match(/^(?:patch|release)-v?(\d+(?:\.\d+\.x)?)$/i)
+  const match = branch.match(/^(patch|release)-v?(\d+(?:\.\d+\.x)?)$/i)
   if (!match) {
     return null
   }
 
-  const version = match[1]
+  const branchType = match[1].toLowerCase()
+  const version = match[2]
 
   // Check if it's a semantic version (e.g., "1.2.x")
   const semverMatch = version.match(/^(\d+)\.(\d+)\.x$/i)
   if (semverMatch) {
     return {
-      type: 'semver',
+      branchType,
+      versionType: 'semver',
       value: {
         major: parseInt(semverMatch[1], 10),
         minor: parseInt(semverMatch[2], 10)
@@ -28,16 +30,20 @@ function extractVersion (branch) {
 
   // Otherwise it's an integer version
   return {
-    type: 'integer',
+    branchType,
+    versionType: 'integer',
     value: parseInt(version, 10)
   }
 }
 
 /**
  * Compare two branch names by their versions
+ * IMPORTANT: Only compares branches of the same type (patch with patch, release with release)
+ * and same version format (integer with integer, semver with semver)
  * @param {string} a - First branch name
  * @param {string} b - Second branch name
  * @returns {number} - Negative if a < b, positive if a > b, 0 if equal
+ * @throws {Error} - If attempting to compare branches of different types or version formats
  */
 function compareBranches (a, b) {
   const versionA = extractVersion(a)
@@ -48,13 +54,18 @@ function compareBranches (a, b) {
     return a.localeCompare(b)
   }
 
-  // If types differ, compare by type (integer < semver for consistency)
-  if (versionA.type !== versionB.type) {
-    return versionA.type === 'integer' ? -1 : 1
+  // NEVER compare patch branches with release branches
+  if (versionA.branchType !== versionB.branchType) {
+    throw new Error(`Cannot compare branches of different types: ${a} (${versionA.branchType}) vs ${b} (${versionB.branchType})`)
+  }
+
+  // NEVER compare integer versions with semver versions
+  if (versionA.versionType !== versionB.versionType) {
+    throw new Error(`Cannot compare branches with different version formats: ${a} (${versionA.versionType}) vs ${b} (${versionB.versionType})`)
   }
 
   // Compare integer versions
-  if (versionA.type === 'integer') {
+  if (versionA.versionType === 'integer') {
     return versionA.value - versionB.value
   }
 

--- a/test/version-comparison.test.js
+++ b/test/version-comparison.test.js
@@ -41,46 +41,53 @@ describe('Version Comparison', () => {
   describe('extractVersion', () => {
     test('extracts integer version from release branch', () => {
       expect(extractVersion('release-147')).toEqual({
-        type: 'integer',
+        branchType: 'release',
+        versionType: 'integer',
         value: 147
       })
     })
 
     test('extracts integer version from patch branch', () => {
       expect(extractVersion('patch-42')).toEqual({
-        type: 'integer',
+        branchType: 'patch',
+        versionType: 'integer',
         value: 42
       })
     })
 
     test('extracts semver from release branch with v prefix', () => {
       expect(extractVersion('release-v1.2.x')).toEqual({
-        type: 'semver',
+        branchType: 'release',
+        versionType: 'semver',
         value: { major: 1, minor: 2 }
       })
     })
 
     test('extracts semver from release branch without v prefix', () => {
       expect(extractVersion('release-1.2.x')).toEqual({
-        type: 'semver',
+        branchType: 'release',
+        versionType: 'semver',
         value: { major: 1, minor: 2 }
       })
     })
 
     test('extracts semver from patch branch', () => {
       expect(extractVersion('patch-v3.5.x')).toEqual({
-        type: 'semver',
+        branchType: 'patch',
+        versionType: 'semver',
         value: { major: 3, minor: 5 }
       })
     })
 
     test('handles case insensitive branch names', () => {
       expect(extractVersion('RELEASE-100')).toEqual({
-        type: 'integer',
+        branchType: 'release',
+        versionType: 'integer',
         value: 100
       })
       expect(extractVersion('PATCH-V2.1.X')).toEqual({
-        type: 'semver',
+        branchType: 'patch',
+        versionType: 'semver',
         value: { major: 2, minor: 1 }
       })
     })
@@ -146,10 +153,29 @@ describe('Version Comparison', () => {
       })
     })
 
-    describe('mixed version types', () => {
-      test('integer versions come before semver versions', () => {
-        expect(compareBranches('release-100', 'release-v1.0.x')).toBeLessThan(0)
-        expect(compareBranches('release-v1.0.x', 'release-100')).toBeGreaterThan(0)
+    describe('cross-type comparison prevention', () => {
+      test('throws error when comparing patch with release branches', () => {
+        expect(() => compareBranches('patch-1', 'release-1')).toThrow('Cannot compare branches of different types')
+        expect(() => compareBranches('release-100', 'patch-50')).toThrow('Cannot compare branches of different types')
+      })
+
+      test('throws error when comparing patch semver with release semver', () => {
+        expect(() => compareBranches('patch-v1.0.x', 'release-v1.0.x')).toThrow('Cannot compare branches of different types')
+      })
+
+      test('throws error when comparing integer with semver versions (release)', () => {
+        expect(() => compareBranches('release-100', 'release-v1.0.x')).toThrow('Cannot compare branches with different version formats')
+        expect(() => compareBranches('release-v1.0.x', 'release-100')).toThrow('Cannot compare branches with different version formats')
+      })
+
+      test('throws error when comparing integer with semver versions (patch)', () => {
+        expect(() => compareBranches('patch-100', 'patch-v1.0.x')).toThrow('Cannot compare branches with different version formats')
+        expect(() => compareBranches('patch-v1.0.x', 'patch-100')).toThrow('Cannot compare branches with different version formats')
+      })
+
+      test('throws error when comparing mixed types and formats', () => {
+        expect(() => compareBranches('patch-100', 'release-v1.0.x')).toThrow('Cannot compare branches of different types')
+        expect(() => compareBranches('release-v2.0.x', 'patch-50')).toThrow('Cannot compare branches of different types')
       })
     })
 
@@ -167,22 +193,43 @@ describe('Version Comparison', () => {
     })
 
     describe('sorting arrays', () => {
-      test('sorts integer versions correctly', () => {
+      test('sorts release integer versions correctly', () => {
         const branches = ['release-2', 'release-152', 'release-10', 'release-147', 'release-1']
         const sorted = branches.sort(compareBranches)
         expect(sorted).toEqual(['release-1', 'release-2', 'release-10', 'release-147', 'release-152'])
       })
 
-      test('sorts semver versions correctly', () => {
+      test('sorts patch integer versions correctly', () => {
+        const branches = ['patch-5', 'patch-100', 'patch-1', 'patch-50']
+        const sorted = branches.sort(compareBranches)
+        expect(sorted).toEqual(['patch-1', 'patch-5', 'patch-50', 'patch-100'])
+      })
+
+      test('sorts release semver versions correctly', () => {
         const branches = ['release-v1.10.x', 'release-v1.2.x', 'release-v2.1.x', 'release-v1.9.x']
         const sorted = branches.sort(compareBranches)
         expect(sorted).toEqual(['release-v1.2.x', 'release-v1.9.x', 'release-v1.10.x', 'release-v2.1.x'])
       })
 
-      test('sorts mixed versions correctly', () => {
-        const branches = ['release-v1.0.x', 'release-100', 'release-2', 'release-v2.0.x']
+      test('sorts patch semver versions correctly', () => {
+        const branches = ['patch-v2.5.x', 'patch-v1.10.x', 'patch-v1.2.x']
         const sorted = branches.sort(compareBranches)
-        expect(sorted).toEqual(['release-2', 'release-100', 'release-v1.0.x', 'release-v2.0.x'])
+        expect(sorted).toEqual(['patch-v1.2.x', 'patch-v1.10.x', 'patch-v2.5.x'])
+      })
+
+      test('cannot sort array with mixed branch types', () => {
+        const branches = ['release-1', 'patch-1', 'release-2']
+        expect(() => branches.sort(compareBranches)).toThrow('Cannot compare branches of different types')
+      })
+
+      test('cannot sort array with mixed version formats (release)', () => {
+        const branches = ['release-v1.0.x', 'release-100', 'release-2', 'release-v2.0.x']
+        expect(() => branches.sort(compareBranches)).toThrow('Cannot compare branches with different version formats')
+      })
+
+      test('cannot sort array with mixed version formats (patch)', () => {
+        const branches = ['patch-v1.0.x', 'patch-50', 'patch-1', 'patch-v2.0.x']
+        expect(() => branches.sort(compareBranches)).toThrow('Cannot compare branches with different version formats')
       })
     })
   })


### PR DESCRIPTION
- Never compare patch branches with release branches
- Never compare integer versions with semver versions
- Update extractVersion() to return branchType and versionType
- Update compareBranches() to throw errors on incompatible comparisons
- Filter branches by both type and version format in index.js
- Add comprehensive tests for all comparison restrictions